### PR TITLE
Correcting keyboard shortcut for new buffer

### DIFF
--- a/content/wiki/miscellaneous/_index.md
+++ b/content/wiki/miscellaneous/_index.md
@@ -23,7 +23,7 @@ Those features include:
 ## APEX keyboard shortcuts
 
 There are a few keyboard shortcuts for APEX:  
-- **Ctrl + Shift** opens up a new, empty buffer.  
+- **Ctrl + Space** opens up a new, empty buffer.  
 - **Escape** closes the currently selected buffer.  
 
 ## APEX chat commands


### PR DESCRIPTION
Ctrl + Shift does not launch a new buffer. Ctrl + Space works in Chrome, reported not to work in Firefox, but Ctrl + Shift works not at all in either.