### PR TITLE
Update Metallurgist Recommended Planet

### DIFF
--- a/content/wiki/packages-factions/_index.md
+++ b/content/wiki/packages-factions/_index.md
@@ -6,25 +6,25 @@ weight: 4
 
 This page will help you find a suitable combination of package, faction and starting location when first establishing your company. Following the advice below is especially vital if you are new to APEX. You best settle on a package first and then have a look at the different factions and the planets they control. Certain planets are better suited for some professions than others, and some planets and professions do not work together at all! But of course, the better suited a planet is for your industry, the higher the local competition will be.
 
-__Please note:__  
-- Some recommended starter planets do not have a commodity exchange. These are not recommended if you are using APEX for the first time.  
+__Please note:__
+- Some recommended starter planets do not have a commodity exchange. These are not recommended if you are using APEX for the first time.
 - When setting up your base, two additional Pioneer Habitation modules are recommended regardless of package.
 
 ## Packages
 
 ### Victualler
-__Short description__  
+__Short description__
 Producing agricultural products that can be used in the food industries is the foundation of every colony.
 
-__Long description__  
+__Long description__
 Victuallers are the heart of the food industry. Their profession revolves around extracting water, producing ingredients and turning it all into edibles for their own and others' workforces. Without victuallers, all other industries would soon come to a halt, which is why their trade will always be relevant across the universe.
 
 #### Important notes
 As a victualler, you will depend on water. If you do not settle on a planet with water, you will have a hard time turning a profit. The speed at which the crops on your farms will grow depends on a planet's soil fertility - the higher the fertility, the quicker the growth.
 
 #### Recommended starter buildings
-__Rig (RIG):__ Extracts liquids (water) from the ground.  
-__Farmstead (FRM):__ Requires water to output different integredients used in food production and adjacent industries.  
+__Rig (RIG):__ Extracts liquids (water) from the ground.
+__Farmstead (FRM):__ Requires water to output different integredients used in food production and adjacent industries.
 __Food Processor (FP):__ Takes food ingredients and turns them into consumables.
 
 #### Recommended starter planet
@@ -36,38 +36,38 @@ Proxion (Castillo-Ito Mercantile)
 
 
 ### Metallurgist
-__Short description__  
+__Short description__
 Metallurgists have all the knowledge and tools necessary to extract minerals and refine them into precious metals and composites.
 
-__Long description__  
+__Long description__
 If you don't mind getting your (workers') hands dirty, this might be the job for you. Operating at the base of several industry branches, metallurgists produce ores, smelt them down and supply their trade partners with refined metals that will ultimately go into the construction of buildings, ships, and other structures.
 
 #### Important notes
 Extracting ores from the ground will be an essential everyday task for your company. Make sure that your planet contains at least one mineral, or you will not be able to put your Extractor to use. Plus, if that mineral is not an ore, you cannot put it into your smelter.
 
 #### Recommended starter buildings
-__Extractor (EXT):__ Extracts ores from a planet's surface.  
+__Extractor (EXT):__ Extracts ores from a planet's surface.
 __Smelter (SME):__ Refines ores into metals.
 
 #### Recommended starter planet
-Montem (NEO Charter Exploration)  
+Vallis (NEO Charter Exploration)
 
 #### Starting Experts
 2 Metallurgy Experts
 
 
 ### Carbon Farmer
-__Short description__  
+__Short description__
 Carbon farmers grow plants and extract carbon from them.
 
-__Long description__  
+__Long description__
 Carbon has become a vital resource across different industries, so much so that a whole job profile has evolved around it: the carbon farmer. Even though you will be planting crops like a victualler, you will not have much to do with the food industry. Instead, your plants will be harvested for their precious carbon, which is the basis for many essential production processes in the metal and other industries.
 
 #### Important notes
 Setting up shop on a planet with higher fertility will help increase your farms' output. If a planet is completely infertile, farms cannot be built at all, leaving your company dead in the water!
 
 #### Recommended starter buildings
-__Farmstead (FRM) (2x):__ Requires water to output different integredients used in food production and adjacent industries.  
+__Farmstead (FRM) (2x):__ Requires water to output different integredients used in food production and adjacent industries.
 __Incinerator (INC):__ Extracts pure carbon from different carbon-rich plants.
 
 #### Recommended starter planets
@@ -78,10 +78,10 @@ Promitor (Insitor Cooperative)
 
 
 ### Manufacturer
-__Short description__  
+__Short description__
 Manufacturers produce construction granulate, tools and plastics for their trade partners to process further.
 
-__Long description__  
+__Long description__
 As a manufacturer, you will be a versatile creature which does not depend too much on a single industry. Your company's main purpose will be to supply your trade partners with goods such as basic clothing and building parts. Getting started as a manufacturer is quite complex logistically, as you will have to buy your input materials from a nearby commodity exchange.
 
 #### Important notes
@@ -91,18 +91,18 @@ Your production lines will need hydrogen and carbon to operate. Hydrogen can be 
 __Basic Materials Plant (BMP) (2x):__ Produces a host of materials and end products needed to bootstrap a colony.
 
 #### Recommended starter planets
-Vallis (NEO Charter Exploration)  
-Gibson (Castillo-Ito Mercantile)  
+Vallis (NEO Charter Exploration)
+Gibson (Castillo-Ito Mercantile)
 
 #### Starting Experts
 2 Manufacturing Experts
 
 
 ### Constructor
-__Short description__  
+__Short description__
 Constructors know their way around building parts, from basic structural elements to complex engineering materials.
 
-__Long description__  
+__Long description__
 You and your fellow constructors will be the key element to expanding existing bases or establishing new ones. Your output materials, mostly polyethylene and different building parts, will go toward the construction of your and your clients' buildings.
 
 #### Important notes
@@ -110,35 +110,35 @@ Since you will not be extracting or mining yourself, your production will requir
 
 #### Recommended starter buildings
 __Basic Materials Plant (BMP):__ Produces a host of materials and end products needed to bootstrap a colony.  
-__Prefab Plant Mk1 (PP1):__ Produces basic prefabs necessary to construct buildings.  
+__Prefab Plant Mk1 (PP1):__ Produces basic prefabs necessary to construct buildings.
 
 #### Recommended starter planets
-Montem (NEO Charter Exploration)  
+Montem (NEO Charter Exploration)
 Vallis (NEO Charter Exploration)
-Gibson (Castillo-Ito Mercantile)  
+Gibson (Castillo-Ito Mercantile)
 
 #### Starting Experts
 2 Construction Experts
 
 
 ### Fuel Engineer
-__Short description__  
+__Short description__
 Fuel engineers extract resources and synthesize them to different types of fuels.
 
-__Long description__  
+__Long description__
 The commodities you produce will be the foundation of faster-than-light and slower-than-light space travel. Both fuel types are based on a variety of gaseous and solid ingredients, so there is plenty of room for development and specialization in your trade.
 
 #### Important notes
 Your Extractor will only be useful in STL fuel production if there is Galerite on your planet. You could instead opt for a Collector and settle on a planet prodiving Ammonia or Hydrogen.
 
 #### Recommended starter buildings
-__Refinery (REF):__ Produces fuels used for space flight.  
-_Instead of Collector:_ __Extractor (EXT):__ Extracts ores and minerals from the surface.  
-_Instead of Extractor:_ __Collector (COL):__  Extracts gases from the atmosphere.  
+__Refinery (REF):__ Produces fuels used for space flight.
+_Instead of Collector:_ __Extractor (EXT):__ Extracts ores and minerals from the surface.
+_Instead of Extractor:_ __Collector (COL):__  Extracts gases from the atmosphere.
 
 #### Recommended starter planets
-_With Extractor:_ Katoa (Castillo-Ito Mercantile)  
-_With Collector:_ Katoa (Castillo-Ito Mercantile)  
+_With Extractor:_ Katoa (Castillo-Ito Mercantile)
+_With Collector:_ Katoa (Castillo-Ito Mercantile)
 
 #### Starting Experts
 2 Fuel Refining Experts


### PR DESCRIPTION
Changed the Metallurgist Recommended Planet from Montem to Vallis.
Reasoning: Montem CoGC is set to Chemistry while Vallis is set to Metallurgy

Also deleted trailing whitespace.